### PR TITLE
HX-13-Alterar-configure.sh-e-HX-para-gerar-UUIDs-versao-4-que-nao-levam-em-consideracao-dados-fisicos-da-maquina

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -68,7 +68,7 @@
 #
 # $HexagonixOS$
 
-# Versão 4.2.2
+# Versão 4.3.0
 
 # $PORTUGUÊS$
 #
@@ -567,7 +567,7 @@ export CONFIGURE1=$2
 export CONFIGURE2=$3
 export CONFIGURE3=$4
 export CONFIGURE4=$5
-export BUILD=$(uuid)
+export BUILD=$(uuid -m -v 4)
 export LANCAMENTO=$(cat Dist/etc/release.def)
 export CODENOME=$(cat Dist/etc/codenome.def)
 export VERSAO=$(cat Dist/etc/versao.def)

--- a/hx
+++ b/hx
@@ -1866,7 +1866,11 @@ export PT4=$4
 export PT5=$5
 export IDIOMA=$2
 export IDIOMANG=$3
-export ID_BUILD=$(uuid)
+export ID_BUILD=$(uuid -m -v 4)
+
+# Versão do hx
+
+export VERSAOHX="13.15.6.1"
 
 # Variáveis e constantes utilizados na montagem e no QEMU
 
@@ -1960,10 +1964,6 @@ export RAMO=$(git branch --show-current)
 cd ..
 
 fi
-
-# Versão do hx
-
-export VERSAOHX="13.15.6.0"
 
 # Realizar a ação determinada pelo parâmetro fornecido
 


### PR DESCRIPTION
Uso de uuid version 4 para gerar identificadores de build sem dados derivados da máquina física de build do usuário.