### PR TITLE
Build support for the new /shadow database

### DIFF
--- a/Contrib.sh
+++ b/Contrib.sh
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -125,7 +125,7 @@ function showVersion() {
 
 echo "hx build module for contrib packages, version $CONTRIB_VERSION"
 echo
-echo -e "\e[0mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Hexagonix Operating System
 
 BSD 3-Clause License
 
-Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes<br>
+Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes<br>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/configure.sh
+++ b/configure.sh
@@ -489,22 +489,73 @@ finish
 
 }
 
+# DJB2 hash, matching Hexagon.LibASM.PasswdHash.hash (lib/fasm/passwdHash.s)
+# byte for byte: hash = 5381, then hash = hash*33 + c for each character,
+# masked to 32 bits, formatted as 8 lowercase hex digits. Not cryptographic,
+# the same tradeoff the kernel-side implementation documents, the point is
+# that shadow.conf's plaintext passwords never reach the built disk image,
+# not that the hash resists a determined attacker
+
+function djb2Hash() {
+
+local text="$1"
+local hash=5381
+local i c
+
+for (( i=0; i<${#text}; i++ )); do
+
+c=$(printf '%d' "'${text:$i:1}")
+hash=$(( (hash * 33 + c) & 0xFFFFFFFF ))
+
+done
+
+printf '%08x' "$hash"
+
+}
+
 function users() {
 
 echo -e "Configuring users..."
 
 cd Dist/etc
 
-if [ -e passwd ] ; then
+if [ -e shadow ] ; then
 
 echo " > Removing previous user database..."
 
-sudo rm passwd
+sudo rm shadow
 
 fi
 
 echo -n " > Processing .conf file and creating user database... "
-echo -e $(cat passwd.conf) >> passwd
+
+# shadow.conf is username:password:code:shell:theme, one real line per
+# account, plaintext, never shipped itself. Each line's password field
+# gets hashed here before it's written to the shadow file that actually
+# ends up on the built disk image
+
+while IFS= read -r configLine || [ -n "$configLine" ]; do
+
+case "$configLine" in
+
+""|"#"*)
+continue
+;;
+
+esac
+
+configUser=$(echo "$configLine" | cut -d: -f1)
+configPassword=$(echo "$configLine" | cut -d: -f2)
+configCode=$(echo "$configLine" | cut -d: -f3)
+configShell=$(echo "$configLine" | cut -d: -f4)
+configTheme=$(echo "$configLine" | cut -d: -f5)
+
+configHash=$(djb2Hash "$configPassword")
+
+echo "${configUser}:${configHash}:${configCode}:${configShell}:${configTheme}" >> shadow
+
+done < shadow.conf
+
 echo -e "[\e[32mOk\e[0m]"
 
 cd ..
@@ -630,7 +681,7 @@ echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no war
 
 }
 
-export CONFIGURE_VERSION="6.6.0"
+export CONFIGURE_VERSION="6.7.0"
 
 CONFIGURE1=$2
 CONFIGURE2=$3

--- a/configure.sh
+++ b/configure.sh
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -660,7 +660,7 @@ echo -e "***********************************************************************
 echo
 echo -e " ┌┐ ┌┐                                \e[1;94mHexagonix Operating System\e[0m"
 echo -e " ││ ││"
-echo -e " │└─┘├──┬┐┌┬──┬──┬──┬─┐┌┬┐┌┐ \e[1;94mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e " │└─┘├──┬┐┌┬──┬──┬──┬─┐┌┬┐┌┐ \e[1;94mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e " │┌─┐││─┼┼┼┤┌┐│┌┐│┌┐│┌┐┼┼┼┼┘             \e[1;94mAll rights reserved.\e[0m"
 echo -e " ││ │││─┼┼┼┤┌┐│└┘│└┘││││├┼┼┐"
 echo -e " └┘ └┴──┴┘└┴┘└┴─┐├──┴┘└┴┴┘└┘"
@@ -676,7 +676,7 @@ function showVersion() {
 
 echo "hx build configuration module, version $CONFIGURE_VERSION"
 echo
-echo -e "\e[0mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }

--- a/hx
+++ b/hx
@@ -522,7 +522,7 @@ echo -e "   > \e[1;94mUse ./hx with parameters to regenerate these files.\e[0m"
 echo -e "   > For help on possible parameters, use ./hx -h."
 echo -n " > Removing configuration files generated every build..."
 
-rm -rf Dist/etc/*.unx Dist/etc/*.ocl Dist/etc/rc Dist/etc/passwd Dist/etc/shrc Dist/etc/host
+rm -rf Dist/etc/*.unx Dist/etc/*.ocl Dist/etc/rc Dist/etc/shadow Dist/etc/shrc Dist/etc/host
 
 echo -e " [\e[32mOk\e[0m]"
 echo -e "   > \e[1;94mUse ./configure.sh to regenerate these files.\e[0m"
@@ -641,7 +641,7 @@ exit
 
 
 export HX_NAME=$0
-export HX_VERSION="15.3.2"
+export HX_VERSION="15.4.0"
 
 # Modules directory
 

--- a/hx
+++ b/hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -308,7 +308,7 @@ function showVersion() {
 
 echo -e "hx: Hexagonix build utility, version $HX_VERSION"
 echo
-echo -e "\e[0mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }
@@ -633,7 +633,7 @@ exit
 # Hx entry point, variable definition and parameter processing
 #
 #
-# Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 # All rights reserved
 
 # hx info

--- a/indent.sh
+++ b/indent.sh
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -190,7 +190,7 @@ function showVersion()
 {
 echo "hx build module for source indentation, version $INDENT_VERSION"
 echo
-echo -e "\e[0mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }

--- a/modules/andromeda.hx
+++ b/modules/andromeda.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/buildInfo.hx
+++ b/modules/buildInfo.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/buildOnBSD.hx
+++ b/modules/buildOnBSD.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/buildOnLinux.hx
+++ b/modules/buildOnLinux.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/buildOnUNIX.hx
+++ b/modules/buildOnUNIX.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/common.hx
+++ b/modules/common.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -128,7 +128,7 @@ echo -e "***********************************************************************
 echo
 echo -e " ┌┐ ┌┐                                \e[1;94mHexagonix Operating System\e[0m"
 echo -e " ││ ││"
-echo -e " │└─┘├──┬┐┌┬──┬──┬──┬─┐┌┬┐┌┐ \e[1;94mCopyright (c) 2015-2025 Felipe Miguel Nery Lunkes\e[0m"
+echo -e " │└─┘├──┬┐┌┬──┬──┬──┬─┐┌┬┐┌┐ \e[1;94mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e " │┌─┐││─┼┼┼┤┌┐│┌┐│┌┐│┌┐┼┼┼┼┘             \e[1;94mAll rights reserved.\e[0m"
 echo -e " ││ │││─┼┼┼┤┌┐│└┘│└┘││││├┼┼┐"
 echo -e " └┘ └┴──┴┘└┴┘└┴─┐├──┴┘└┴┴┘└┘"

--- a/modules/contribBuilder.hx
+++ b/modules/contribBuilder.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/contribChecker.hx
+++ b/modules/contribChecker.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/depend.hx
+++ b/modules/depend.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/fonts.hx
+++ b/modules/fonts.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/git.hx
+++ b/modules/git.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/hboot.hx
+++ b/modules/hboot.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/hexagon.hx
+++ b/modules/hexagon.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/logUtils.hx
+++ b/modules/logUtils.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -105,7 +105,7 @@ fi
 echo -e "Hexagonix Operating System build and statistics report" >> $LOG
 echo "-------------------------------------------------------" >> $LOG
 echo -e "\nHexagonix Operating System" >> $LOG
-echo "Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes" >> $LOG
+echo "Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes" >> $LOG
 echo "All rights reserved." >> $LOG
 echo -e "\nHexagonix is licenced under BSD-3-Clause and comes with no warranty.\n" >> $LOG
 echo "-------------------------------------------------------" >> $LOG

--- a/modules/macros.hx
+++ b/modules/macros.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/saturno.hx
+++ b/modules/saturno.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/stat.hx
+++ b/modules/stat.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/systemBuilder.hx
+++ b/modules/systemBuilder.hx
@@ -109,9 +109,9 @@ cp rc $BUILD_DIRECTORY/etc
 
 echo " > rc successfully copied." >> $LOG
 
-cp passwd $BUILD_DIRECTORY/etc
+cp shadow $BUILD_DIRECTORY/etc
 
-echo " > passwd successfully copied." >> $LOG
+echo " > shadow successfully copied." >> $LOG
 
 cp host $BUILD_DIRECTORY/etc
 
@@ -202,6 +202,6 @@ callHXMod contribBuilder
 
 # Constants
 
-MOD_VER="0.3"
+MOD_VER="0.4"
 
 main $1

--- a/modules/systemBuilder.hx
+++ b/modules/systemBuilder.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/unix.hx
+++ b/modules/unix.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/vm.hx
+++ b/modules/vm.hx
@@ -15,7 +15,7 @@
 #
 #                    Sistema Operacional Hexagonix - Hexagonix Operating System
 #
-#                         Copyright (c) 2015-2025 Felipe Miguel Nery Lunkes
+#                         Copyright (c) 2015-2026 Felipe Miguel Nery Lunkes
 #                        Todos os direitos reservados - All rights reserved.
 #
 #*************************************************************************************************
@@ -38,7 +38,7 @@
 #
 # BSD 3-Clause License
 #
-# Copyright (c) 2015-2025, Felipe Miguel Nery Lunkes
+# Copyright (c) 2015-2026, Felipe Miguel Nery Lunkes
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without

--- a/modules/vm.hx
+++ b/modules/vm.hx
@@ -181,7 +181,7 @@ echo
 
 # Constants
 
-MOD_VER="0.3"
+MOD_VER="0.4"
 
 # Constants for virtual machine execution (QEMU)
 
@@ -189,7 +189,7 @@ DRV_SOUND="pcspk"
 SYSTEM_ARCH="i386"
 BSD_SYSTEM_ARCH="x86_64"
 PROCESSOR="pentium3"
-MEMORY=32
+MEMORY=64
 AUDIO_DEVICE="pa,id=audio0 -machine pcspk-audiodev=audio0"
 
 main $1


### PR DESCRIPTION
- configure.sh: builds Dist/etc/shadow from shadow.conf, hashing each plaintext password with the same DJB2 routine as passwdHash.s, so plaintext passwords never reach the built disk image;
- hx: cleanup step now removes the generated Dist/etc/shadow instead of the old passwd file;
- vm.hx: default VM memory raised from 32 MB to 64 MB;
- Copyright year and version bumps.