### PR TITLE
Hexagonix 1.0 build scripts and modules

### DIFF
--- a/Contrib.sh
+++ b/Contrib.sh
@@ -94,6 +94,8 @@ function buildContribPackages() {
 echo -e "\e[1;94mBuilding additional packages for Hexagonix...\e[0m {"
 echo
 
+mkdir -p $BUILD_DIRECTORY/contrib
+
 cd fasmX/
 
 cd SOURCE
@@ -105,7 +107,7 @@ do
     echo -n " > Generating additional (contrib) application $(basename $i .asm)..." >> $LOG
     echo -en "Generating additional (contrib) application \e[1;94m$(basename $i .asm)\e[0m..."
 
-    fasm $i $BUILD_DIRECTORY/bin/`basename $i .asm` -d $COMMON_FLAGS >> /dev/null || echo " [Fail]"
+    fasm $i $BUILD_DIRECTORY/contrib/`basename $i .asm` -d $COMMON_FLAGS >> /dev/null || echo " [Fail]"
 
     echo -e " [\e[32mOk\e[0m]"
     echo " [Ok]" >> $LOG
@@ -130,6 +132,6 @@ echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no war
 
 }
 
-export CONTRIB_VERSION="3.0.1"
+export CONTRIB_VERSION="3.0.2"
 
 main $1

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ O `HX` é a ferramenta responsável por unificar toda a construção do Hexagoni
 | `--version`| Exibe informações de versão e copyright|
 | `--depend`| Instala as dependências de construção (sistemas Debian, Ubuntu e derivados, apenas)|
 | `--info`| Exibe informações do Hexagonix, como versão, revisão, ramo de desenvolvimento, etc|
-| `--indent`| Inicializa o `indent.sh`, que formata e otimiza os códigos-fonte, manuais e arquivos de definição do Hexagonix|
+| `--format`| Inicializa o `formatter.sh`, que formata e otimiza os códigos-fonte, manuais e arquivos de definição do Hexagonix|
 | `--configure`| Executa o `configure.sh` para gerar os arquivos estáticos necessários para a construção|
 | `--stats`| Exibe informações estatísticas sobre o Hexagonix (necessário cloc instalado)|
 | `--flags`| Exibe as flags de build atualmente configuradas para o HBoot, o Hexagon e os utilitários userland|
@@ -115,7 +115,7 @@ Para a construção do Hexagonix, o `hx` procura e executa uma série de módulo
 <div align="justify">
 
 * `configure.sh`: deve estar no diretório raiz da árvore de construção. É responsável por checar dependências e gerar os arquivos estáticos necessários à construção do Hexagonix, como a base de usuários `/shadow` (com as senhas em `Dist/etc/shadow.conf` já hasheadas) e as informações de build. Sua execução pode ser iniciada diretamente ou pelo `HX`, através de `hx --configure`.
-* `indent.sh`: deve estar no diretório raiz da árvore de construção. Formata e otimiza fontes gráficas, manuais e arquivos de definição do Hexagonix. Pode ser iniciado pelo `HX`, através de `hx --indent`.
+* `formatter.sh`: deve estar no diretório raiz da árvore de construção. Formata e otimiza fontes gráficas, manuais e arquivos de definição do Hexagonix. Pode ser iniciado pelo `HX`, através de `hx --format`.
 * `Contrib.sh`: deve estar no diretório raiz da árvore de construção. É responsável por construir e/ou manipular pacotes de terceiros, como o fasmX, cujos repositórios devem estar clonados no interior do diretório `Contrib`.
 
 </div>
@@ -163,7 +163,7 @@ This repository contains tools to build Hexagonix and the system disk images, in
 | `--version`| Displays version and copyright information|
 | `--depend`| Installs build dependencies (Debian, Ubuntu and derivative systems only)|
 | `--info`| Displays Hexagonix information such as version, revision, development branch, etc|
-| `--indent`| Starts `indent.sh`, which formats and optimizes Hexagonix source code, manuals and definition files|
+| `--format`| Starts `formatter.sh`, which formats and optimizes Hexagonix source code, manuals and definition files|
 | `--configure`| Runs `configure.sh` to generate the static files needed for the build|
 | `--stats`| Displays statistical information about Hexagonix (cloc installed required)|
 | `--flags`| Displays the build flags currently configured for HBoot, Hexagon and the userland utilities|
@@ -219,7 +219,7 @@ To build Hexagonix, `hx` looks for and executes a series of modules, located in 
 <div align="justify">
 
 * `configure.sh`: must be in the root directory of the build tree. It is responsible for checking dependencies and generating the static files needed to build Hexagonix, such as the `/shadow` user database (with the passwords in `Dist/etc/shadow.conf` already hashed) and build information. It can be run directly or through `HX`, via `hx --configure`.
-* `indent.sh`: must be in the root directory of the build tree. Formats and optimizes Hexagonix graphic fonts, manuals and definition files. Can be started by `HX`, via `hx --indent`.
+* `formatter.sh`: must be in the root directory of the build tree. Formats and optimizes Hexagonix graphic fonts, manuals and definition files. Can be started by `HX`, via `hx --format`.
 * `Contrib.sh`: must be in the root directory of the build tree. It is responsible for building and/or manipulating third-party packages, such as fasmX, whose repositories must be cloned inside the `Contrib` directory.
 
 </div>

--- a/formatter.sh
+++ b/formatter.sh
@@ -79,7 +79,7 @@
 function main() {
 
 echo
-echo "hx indentation helper version $INDENT_VERSION"
+echo "hx formatting helper version $FORMATTER_VERSION"
 echo
 echo "This tool looks for and fixes indentation and formatting problems in the files"
 echo "that make up the Hexagonix project."
@@ -94,9 +94,9 @@ case $1 in
 -m) optimizeManuals; exit;;
 -d) optimizeDefinitions; exit;;
 -s) optimizeScripts; exit;;
--h) indentHelp; exit;;
+-h) formatterHelp; exit;;
 --version) showVersion; exit;;
-*) indentHelp; exit;;
+*) formatterHelp; exit;;
 
 esac
 
@@ -177,30 +177,30 @@ find . -name 'hx' ! -type d -exec bash -c 'chmod +x hx' {} \;
 
 }
 
-function indentHelp() {
+function formatterHelp() {
 
 echo
 echo -e "\e[1;94mMain\e[0m available parameters:"
 echo
-echo -e "\e[1;32m-a\e[0m - Indent and optimize Hexagonix source files, manuals and definition files."
-echo -e "\e[1;32m-f\e[0m - Indent and optimize Hexagonix x86 Assembly source files only."
-echo -e "\e[1;32m-m\e[0m - Indent and optimize Hexagonix manuals only."
-echo -e "\e[1;32m-d\e[0m - Indent and optimize Hexagonix definition files only."
-echo -e "\e[1;32m-s\e[0m - Indent and optimize Hexagonix scripts and build tools only."
+echo -e "\e[1;32m-a\e[0m - Format and optimize Hexagonix source files, manuals and definition files."
+echo -e "\e[1;32m-f\e[0m - Format and optimize Hexagonix x86 Assembly source files only."
+echo -e "\e[1;32m-m\e[0m - Format and optimize Hexagonix manuals only."
+echo -e "\e[1;32m-d\e[0m - Format and optimize Hexagonix definition files only."
+echo -e "\e[1;32m-s\e[0m - Format and optimize Hexagonix scripts and build tools only."
 echo -e "\e[1;32m-h\e[0m - Display this help."
 echo
 
 }
 
-function showVersion() 
+function showVersion()
 {
-echo "hx build module for source indentation, version $INDENT_VERSION"
+echo "hx build module for source formatting, version $FORMATTER_VERSION"
 echo
 echo -e "\e[0mCopyright (c) 2015-2026 Felipe Miguel Nery Lunkes\e[0m"
 echo -e "hx and hx modules are licensed under BSD-3-Clause and comes with no warranty."
 
 }
 
-export INDENT_VERSION="4.0.1"
+export FORMATTER_VERSION="1.0.0"
 
 main $1

--- a/hx
+++ b/hx
@@ -123,7 +123,7 @@ case $1 in
 --depend) callHXMod depend installBuildDependencies; exit;;
 --info) callHXMod buildInfo infoBuild; exit;;
 --configure) startConfigureModule; exit;;
---indent) startIndentModule; exit;;
+--format) startFormatterModule; exit;;
 --stats) callHXMod stat displayStatistics; exit;;
 --flags) callHXMod buildInfo showBuildFlags; exit;;
 
@@ -533,28 +533,28 @@ echo
 
 }
 
-function startIndentModule() {
+function startFormatterModule() {
 
 clear
 
-if [ -e Scripts/indent.sh ] ; then
+if [ -e Scripts/formatter.sh ] ; then
 
-cp Scripts/indent.sh .
+cp Scripts/formatter.sh .
 
 echo
-echo -e "[\e[32mAllowing execution and starting indent.sh (using '-a' parameter)...\e[0m]"
+echo -e "[\e[32mAllowing execution and starting formatter.sh (using '-a' parameter)...\e[0m]"
 
 # First, make sure the file can be executed
 
-chmod +x indent.sh
+chmod +x formatter.sh
 
-./indent.sh -a
+./formatter.sh -a
 
-rm indent.sh
+rm formatter.sh
 
 else
 
-echo -e "[\e[31mError: indent.sh not found\e[0m]."
+echo -e "[\e[31mError: formatter.sh not found\e[0m]."
 
 fi
 
@@ -641,7 +641,7 @@ exit
 
 
 export HX_NAME=$0
-export HX_VERSION="15.4.1"
+export HX_VERSION="15.5.0"
 
 # Modules directory
 

--- a/indent.sh
+++ b/indent.sh
@@ -124,6 +124,12 @@ find . -name '*.asm' ! -type d -exec bash -c 'sed -i "s/[[:blank:]]\{1,\}$//" "$
 find . -name '*.s' ! -type d -exec bash -c 'sed -i "s/[[:blank:]]\{1,\}$//" "$0"' {} \;
 find . -name '*.cow' ! -type d -exec bash -c 'sed -i "s/[[:blank:]]\{1,\}$//" "$0"' {} \;
 
+echo -e "> \e[32mSearching and squeezing repeated blank lines in Hexagonix source and related files...\e[0m"
+
+find . -name '*.asm' ! -type d -exec bash -c 'sed -i "/^$/{N;/^\n$/D}" "$0"' {} \;
+find . -name '*.s' ! -type d -exec bash -c 'sed -i "/^$/{N;/^\n$/D}" "$0"' {} \;
+find . -name '*.cow' ! -type d -exec bash -c 'sed -i "/^$/{N;/^\n$/D}" "$0"' {} \;
+
 }
 
 function optimizeDefinitions() {

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -136,13 +136,12 @@ cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common 
 
 cp $BUILD_DIRECTORY/boot/* $MOUNT_POINT_DIRECTORY/ >> $LOG || callHXMod common buildError
 
-# Every built application, Unix, Andromeda, and Contrib packages like
-# fasmX alike, lands in $BUILD_DIRECTORY/bin, so this is a plain copy with
-# nothing to keep in sync by hand as applications come and go. /sbin then
-# carries off just init (the kernel looks for it at /sbin/init directly),
-# login and everything only login itself needs (logind), and whatever
-# manages the running system (shutdown, ps, top); everything else stays in
-# /bin
+# Every built application, Unix and Andromeda alike, lands in
+# $BUILD_DIRECTORY/bin, so this is a plain copy with nothing to keep in
+# sync by hand as applications come and go. /sbin then carries off just
+# init (the kernel looks for it at /sbin/init directly), login and
+# everything only login itself needs (logind), and whatever manages the
+# running system (shutdown, ps, top); everything else stays in /bin
 
 mkdir $MOUNT_POINT_DIRECTORY/bin
 cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY/bin/ >> $LOG || callHXMod common buildError
@@ -152,6 +151,13 @@ mkdir $MOUNT_POINT_DIRECTORY/sbin
 for f in init login logind shutdown ps top ; do
 mv $MOUNT_POINT_DIRECTORY/bin/$f $MOUNT_POINT_DIRECTORY/sbin/$f >> $LOG || callHXMod common buildError
 done
+
+# Contrib packages, like fasmX, are third party and built separately from
+# the rest of the system, so they get their own place instead of mixing
+# into /bin with everything Hexagonix itself ships
+
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/contrib
+cp $BUILD_DIRECTORY/contrib/* $MOUNT_POINT_DIRECTORY/usr/contrib/ >> $LOG || callHXMod common buildError
 
 # License must be copied
 
@@ -271,6 +277,6 @@ exit
 
 # Constants
 
-MOD_VER="0.8"
+MOD_VER="0.9"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -125,11 +125,11 @@ mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/cowsay
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/man
 mkdir -p $MOUNT_POINT_DIRECTORY/lib/asm
 
-cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/share/man >> $LOG || callHXMod common buildError
-cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
-cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY/lib/asm >> $LOG
-cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY/usr/share/cowsay >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY/home >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY/usr/share/cowsay >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/share/man >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY/lib/asm >> $LOG
+cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
 
 # Everything under $BUILD_DIRECTORY/boot (the kernel, HBoot, and any HBoot
 # modules) belongs at the / directory
@@ -277,6 +277,6 @@ exit
 
 # Constants
 
-MOD_VER="0.11"
+MOD_VER="0.12"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -119,7 +119,8 @@ fi
 
 echo -e "> Copying system files to the image...\n" >> $LOG
 
-cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/man
+cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/man >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
 cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY >> $LOG
 cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
@@ -270,6 +271,6 @@ exit
 
 # Constants
 
-MOD_VER="0.7"
+MOD_VER="0.8"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -120,14 +120,15 @@ fi
 echo -e "> Copying system files to the image...\n" >> $LOG
 
 mkdir -p $MOUNT_POINT_DIRECTORY/home
-mkdir -p $MOUNT_POINT_DIRECTORY/usr/man
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/fonts
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/cowsay
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/man
 mkdir -p $MOUNT_POINT_DIRECTORY/lib/asm
 
-cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/man >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/share/man >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
 cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY/lib/asm >> $LOG
-cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY/usr/share/cowsay >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY/home >> $LOG || callHXMod common buildError
 
 # Everything under $BUILD_DIRECTORY/boot (the kernel, HBoot, and any HBoot
@@ -276,6 +277,6 @@ exit
 
 # Constants
 
-MOD_VER="0.10"
+MOD_VER="0.11"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -123,49 +123,42 @@ cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common bui
 cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
 cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY >> $LOG
 cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
-cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
-cp $BUILD_DIRECTORY/hboot $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
 
-# When not building image for release, some components should not be present,
-# like OOBE (out of box experience), making testing easier
+# Everything under $BUILD_DIRECTORY/boot (the kernel, HBoot, and any HBoot
+# modules) belongs at the root, loose. HBoot looks the kernel up with a raw
+# FAT16 root-directory short-name scan (Boot/HBoot/Lib/libHexagon.asm),
+# real-mode code that runs before Hexagon (and its directory hierarchy)
+# exists at all. saturno.img/mbr.img are deliberately built straight into
+# $BUILD_DIRECTORY instead, never $BUILD_DIRECTORY/boot, since they're
+# written directly to raw disk sectors below rather than copied as files
 
-if [ "$BUILD_RELEASE_IMAGE" = false ]; then
+cp $BUILD_DIRECTORY/boot/* $MOUNT_POINT_DIRECTORY/ >> $LOG || callHXMod common buildError
 
-# Remove release required components for test build
+# Every built application, Unix, Andromeda, and Contrib packages like
+# fasmX alike, lands in $BUILD_DIRECTORY/bin, so this is a plain copy with
+# nothing to keep in sync by hand as applications come and go. /sbin then
+# carries off just init (the kernel looks for it at /sbin/init directly),
+# login and everything only login itself needs (logind), and whatever
+# manages the running system (shutdown, ps, top); everything else stays in
+# /bin
 
 mkdir $MOUNT_POINT_DIRECTORY/bin
-mkdir $MOUNT_POINT_DIRECTORY/bin/test
-mkdir $MOUNT_POINT_DIRECTORY/bin/test/test2
-mkdir $MOUNT_POINT_DIRECTORY/bin/test/test2/test3
-cp $MOUNT_POINT_DIRECTORY/ls  $MOUNT_POINT_DIRECTORY/bin/ls
-cp $MOUNT_POINT_DIRECTORY/clear  $MOUNT_POINT_DIRECTORY/bin/clear
-cp $MOUNT_POINT_DIRECTORY/ls  $MOUNT_POINT_DIRECTORY/bin/test/ls
-cp $MOUNT_POINT_DIRECTORY/clear  $MOUNT_POINT_DIRECTORY/bin/test/clear
-cp $MOUNT_POINT_DIRECTORY/ls  $MOUNT_POINT_DIRECTORY/bin/test/test2/ls
-cp $MOUNT_POINT_DIRECTORY/clear  $MOUNT_POINT_DIRECTORY/bin/test/test2/clear
-cp $MOUNT_POINT_DIRECTORY/ls  $MOUNT_POINT_DIRECTORY/bin/test/test2/test3/ls
-cp $MOUNT_POINT_DIRECTORY/clear  $MOUNT_POINT_DIRECTORY/bin/test/test2/test3/clear
-cp $MOUNT_POINT_DIRECTORY/dossh $MOUNT_POINT_DIRECTORY/bin/dossh
-cp $MOUNT_POINT_DIRECTORY/oobe $MOUNT_POINT_DIRECTORY/bin/oobe
-rm $MOUNT_POINT_DIRECTORY/oobe
+cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY/bin/ >> $LOG || callHXMod common buildError
 
-fi
+mkdir $MOUNT_POINT_DIRECTORY/sbin
+
+for f in init login logind shutdown ps top ; do
+mv $MOUNT_POINT_DIRECTORY/bin/$f $MOUNT_POINT_DIRECTORY/sbin/$f >> $LOG || callHXMod common buildError
+done
 
 # License must be copied
 
 cp Dist/man/LICENSE $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
 
-# Now copy HBoot modules
-
-if [ -e $BUILD_DIRECTORY/Spartan.mod ] ; then
-
-cp $BUILD_DIRECTORY/*.mod $MOUNT_POINT_DIRECTORY/ >> $LOG
-
-fi
-
 mkdir $MOUNT_POINT_DIRECTORY/etc
 cp $BUILD_DIRECTORY/etc/* $MOUNT_POINT_DIRECTORY/etc >> $LOG || callHXMod common buildError
-cp $BUILD_DIRECTORY/*.ocl $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.ocl $MOUNT_POINT_DIRECTORY/etc >> $LOG || callHXMod common buildError
 
 # If the image should contain a copy of the FreeDOS files for testing...
 
@@ -277,6 +270,6 @@ exit
 
 # Constants
 
-MOD_VER="0.6"
+MOD_VER="0.7"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -119,7 +119,12 @@ fi
 
 echo -e "> Copying system files to the image...\n" >> $LOG
 
+mkdir -p $MOUNT_POINT_DIRECTORY/bin
+mkdir -p $MOUNT_POINT_DIRECTORY/sbin
+mkdir -p $MOUNT_POINT_DIRECTORY/etc
 mkdir -p $MOUNT_POINT_DIRECTORY/home
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/bin
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/contrib
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/fonts
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/cowsay
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/share/man
@@ -136,17 +141,15 @@ cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
 
 cp $BUILD_DIRECTORY/boot/* $MOUNT_POINT_DIRECTORY/ >> $LOG || callHXMod common buildError
 
-# Every built application, Unix and Andromeda alike, lands in
-# $BUILD_DIRECTORY/bin, so this is a plain copy with nothing to keep in
-# sync by hand as applications come and go. /sbin then carries off just
-# init (the kernel looks for it at /sbin/init directly), login and
-# everything only login itself needs (logind), and whatever manages the
+cp $BUILD_DIRECTORY/usr/bin/* $MOUNT_POINT_DIRECTORY/usr/bin/ >> $LOG || callHXMod common buildError
+
+# Every Unix application lands in $BUILD_DIRECTORY/bin, so this is a plain 
+# copy with nothing to keep in sync by hand as applications come and go. 
+# /sbin then carries off just init (the kernel looks for it at /sbin/init directly),
+# login and everything only login itself needs (logind), and whatever manages the
 # running system (shutdown, ps, top). Everything else stays in /bin
 
-mkdir $MOUNT_POINT_DIRECTORY/bin
 cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY/bin/ >> $LOG || callHXMod common buildError
-
-mkdir $MOUNT_POINT_DIRECTORY/sbin
 
 for f in init login logind shutdown ps top ; do
 mv $MOUNT_POINT_DIRECTORY/bin/$f $MOUNT_POINT_DIRECTORY/sbin/$f >> $LOG || callHXMod common buildError
@@ -156,14 +159,12 @@ done
 # the rest of the system, so they get their own place instead of mixing
 # into /bin with everything Hexagonix itself ships
 
-mkdir -p $MOUNT_POINT_DIRECTORY/usr/contrib
 cp $BUILD_DIRECTORY/contrib/* $MOUNT_POINT_DIRECTORY/usr/contrib/ >> $LOG || callHXMod common buildError
 
 # License must be copied
 
 cp Dist/man/LICENSE $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
 
-mkdir $MOUNT_POINT_DIRECTORY/etc
 cp $BUILD_DIRECTORY/etc/* $MOUNT_POINT_DIRECTORY/etc >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/*.ocl $MOUNT_POINT_DIRECTORY/etc >> $LOG || callHXMod common buildError
 
@@ -289,6 +290,6 @@ exit
 
 # Constants
 
-MOD_VER="0.13"
+MOD_VER="0.14"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -151,7 +151,7 @@ cp $BUILD_DIRECTORY/usr/bin/* $MOUNT_POINT_DIRECTORY/usr/bin/ >> $LOG || callHXM
 
 cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY/bin/ >> $LOG || callHXMod common buildError
 
-for f in init login logind shutdown ps top ; do
+for f in init login logind shutdown ps top passwd adduser deluser ; do
 mv $MOUNT_POINT_DIRECTORY/bin/$f $MOUNT_POINT_DIRECTORY/sbin/$f >> $LOG || callHXMod common buildError
 done
 
@@ -290,6 +290,6 @@ exit
 
 # Constants
 
-MOD_VER="0.14"
+MOD_VER="0.15"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -163,7 +163,8 @@ cp $BUILD_DIRECTORY/*.mod $MOUNT_POINT_DIRECTORY/ >> $LOG
 
 fi
 
-cp $BUILD_DIRECTORY/etc/* $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+mkdir $MOUNT_POINT_DIRECTORY/etc
+cp $BUILD_DIRECTORY/etc/* $MOUNT_POINT_DIRECTORY/etc >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/*.ocl $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
 
 # If the image should contain a copy of the FreeDOS files for testing...

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -248,6 +248,18 @@ echo "> Creating .vdi image from raw image..." >> $LOG
 
 qemu-img convert -O vdi $IMAGE_PATH/$IMAGE_FILENAME $IMAGE_PATH/$(basename $IMAGE_FILENAME .img).vdi
 
+# qemu-img stamps a new random UUID into the .vdi on every conversion, which breaks
+# VirtualBox VMs that already have this disk registered under a fixed UUID. If VBoxManage
+# is installed, restamp the UUID fixing a UUID to allow updating the disk in VirtualBox VM.
+
+if command -v VBoxManage > /dev/null 2>&1; then
+
+echo "> VBoxManage found, restamping .vdi UUID to match the local VirtualBox VM..." >> $LOG
+
+VBoxManage internalcommands sethduuid $IMAGE_PATH/$(basename $IMAGE_FILENAME .img).vdi {de3feea5-c804-4134-99db-4f5c9f8d15e2} >> $LOG
+
+fi
+
 # Let's now change the image ownership to a regular user
 
 echo "> Adjusting file permissions (needed for git)..." >> $LOG
@@ -277,6 +289,6 @@ exit
 
 # Constants
 
-MOD_VER="0.12"
+MOD_VER="0.13"
 
 main $1

--- a/modules/diskBuilder.hx
+++ b/modules/diskBuilder.hx
@@ -119,20 +119,19 @@ fi
 
 echo -e "> Copying system files to the image...\n" >> $LOG
 
+mkdir -p $MOUNT_POINT_DIRECTORY/home
 mkdir -p $MOUNT_POINT_DIRECTORY/usr/man
+mkdir -p $MOUNT_POINT_DIRECTORY/usr/fonts
+mkdir -p $MOUNT_POINT_DIRECTORY/lib/asm
+
 cp $BUILD_DIRECTORY/*.man $MOUNT_POINT_DIRECTORY/usr/man >> $LOG || callHXMod common buildError
 cp $BUILD_DIRECTORY/*.asm $MOUNT_POINT_DIRECTORY >> $LOG
-cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY >> $LOG
+cp $BUILD_DIRECTORY/*.s $MOUNT_POINT_DIRECTORY/lib/asm >> $LOG
 cp $BUILD_DIRECTORY/*.cow $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
-cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY >> $LOG || callHXMod common buildError
+cp $BUILD_DIRECTORY/shell.sh $MOUNT_POINT_DIRECTORY/home >> $LOG || callHXMod common buildError
 
 # Everything under $BUILD_DIRECTORY/boot (the kernel, HBoot, and any HBoot
-# modules) belongs at the root, loose. HBoot looks the kernel up with a raw
-# FAT16 root-directory short-name scan (Boot/HBoot/Lib/libHexagon.asm),
-# real-mode code that runs before Hexagon (and its directory hierarchy)
-# exists at all. saturno.img/mbr.img are deliberately built straight into
-# $BUILD_DIRECTORY instead, never $BUILD_DIRECTORY/boot, since they're
-# written directly to raw disk sectors below rather than copied as files
+# modules) belongs at the / directory
 
 cp $BUILD_DIRECTORY/boot/* $MOUNT_POINT_DIRECTORY/ >> $LOG || callHXMod common buildError
 
@@ -141,7 +140,7 @@ cp $BUILD_DIRECTORY/boot/* $MOUNT_POINT_DIRECTORY/ >> $LOG || callHXMod common b
 # sync by hand as applications come and go. /sbin then carries off just
 # init (the kernel looks for it at /sbin/init directly), login and
 # everything only login itself needs (logind), and whatever manages the
-# running system (shutdown, ps, top); everything else stays in /bin
+# running system (shutdown, ps, top). Everything else stays in /bin
 
 mkdir $MOUNT_POINT_DIRECTORY/bin
 cp $BUILD_DIRECTORY/bin/* $MOUNT_POINT_DIRECTORY/bin/ >> $LOG || callHXMod common buildError
@@ -186,7 +185,7 @@ if [ -e $BUILD_DIRECTORY/aurora.fnt ] ; then
 
 echo -e " [Yes]\n" >> $LOG
 
-cp $BUILD_DIRECTORY/*.fnt $MOUNT_POINT_DIRECTORY/ || callHXMod common buildError
+cp $BUILD_DIRECTORY/*.fnt $MOUNT_POINT_DIRECTORY/usr/fonts || callHXMod common buildError
 
 fi
 
@@ -277,6 +276,6 @@ exit
 
 # Constants
 
-MOD_VER="0.9"
+MOD_VER="0.10"
 
 main $1

--- a/modules/hboot.hx
+++ b/modules/hboot.hx
@@ -113,11 +113,13 @@ fi
 cd ..
 cd ..
 
-mv hboot $BUILD_DIRECTORY
+mkdir -p $BUILD_DIRECTORY/boot
+
+mv hboot $BUILD_DIRECTORY/boot
 
 if [ -e Spartan.mod ] ; then
 
-mv *.mod $BUILD_DIRECTORY/
+mv *.mod $BUILD_DIRECTORY/boot/
 
 fi
 
@@ -135,6 +137,6 @@ echo -e "----------------------------------------------------------------------\
 
 # Constants
 
-MOD_VERSION="0.3"
+MOD_VERSION="0.4"
 
 main $1

--- a/modules/hexagon.hx
+++ b/modules/hexagon.hx
@@ -86,7 +86,9 @@ echo -e "Building the Hexagon kernel... {\n" >> $LOG
 
 fasm kern/Hexagon.asm hexagon -d $HEXAGON_FLAGS >> $LOG || callHXMod common generalBuildError
 
-mv hexagon $BUILD_DIRECTORY/bin
+mkdir -p $BUILD_DIRECTORY/boot
+
+mv hexagon $BUILD_DIRECTORY/boot
 
 echo -e " [\e[32mOk\e[0m]"
 
@@ -101,6 +103,6 @@ echo -e "----------------------------------------------------------------------\
 
 # Constants
 
-MOD_VERSION="0.3"
+MOD_VERSION="0.4"
 
 main $1

--- a/modules/systemBuilder.hx
+++ b/modules/systemBuilder.hx
@@ -88,8 +88,9 @@ echo "Building the Hexagonix..."
 echo
 
 mkdir -p $BUILD_DIRECTORY
-mkdir -p $BUILD_DIRECTORY/bin
 mkdir -p $BUILD_DIRECTORY/etc
+mkdir -p $BUILD_DIRECTORY/bin
+mkdir -p $BUILD_DIRECTORY/usr/bin
 
 callHXMod saturno
 callHXMod hboot
@@ -205,6 +206,6 @@ callHXMod contribBuilder
 
 # Constants
 
-MOD_VER="0.5"
+MOD_VER="0.6"
 
 main $1

--- a/modules/systemBuilder.hx
+++ b/modules/systemBuilder.hx
@@ -123,6 +123,9 @@ echo " > *.unx files successfully copied." >> $LOG
 
 cp base.ocl $BUILD_DIRECTORY/hexgnix.ocl
 cp shrc $BUILD_DIRECTORY/etc
+cp shell.sh $BUILD_DIRECTORY
+
+echo " > shell.sh successfully copied." >> $LOG
 
 echo " > Hexagonix version files successfully copied." >> $LOG
 
@@ -202,6 +205,6 @@ callHXMod contribBuilder
 
 # Constants
 
-MOD_VER="0.4"
+MOD_VER="0.5"
 
 main $1


### PR DESCRIPTION
- Renames the `indent.sh` utility to `formatter.sh`;
  - Changes the modules used to build the image:
    - `init`, `login`, `logind`, `shutdown`, `ps`, `top`, `passwd`, `adduser` and `deluser` were moved to `/sbin`;
    - The remaining utilities were moved from `/` to `/bin`;
- Changes the VirtualBox image identifier to a fixed one, allowing updated images to be used in VirtualBox without needing to change settings or remove/add a new image;
- Changes the virtual machine memory, via qemu, from 32 to 64 MB.
